### PR TITLE
🐛 Fix: dairy_record_index

### DIFF
--- a/app/models/dairy_record.rb
+++ b/app/models/dairy_record.rb
@@ -4,7 +4,7 @@ class DairyRecord < ApplicationRecord
   validates :total_amount, presence: true
   validates :total_number, presence: true
   validates :count, presence: true
-  validates :date, presence: true, uniqueness: true
+  validates :date, presence: true, uniqueness: { scope: :user_id }
 
   has_many :customer_records, dependent: :destroy
 

--- a/db/migrate/20231215004902_remove_unique_index_from_date_in_dairy_records.rb
+++ b/db/migrate/20231215004902_remove_unique_index_from_date_in_dairy_records.rb
@@ -1,0 +1,6 @@
+class RemoveUniqueIndexFromDateInDairyRecords < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :dairy_records, :date
+    add_index :dairy_records, [:user_id, :date], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_13_091149) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_15_004902) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,7 +40,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_13_091149) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["date"], name: "index_dairy_records_on_date", unique: true
+    t.index ["user_id", "date"], name: "index_dairy_records_on_user_id_and_date", unique: true
     t.index ["user_id"], name: "index_dairy_records_on_user_id"
   end
 


### PR DESCRIPTION
## 概要

全ユーザー間で同じ日付のレコードが一つしか登録できない問題を修正
issue: #11 

## 変更点
- マイグレーション修正
- モデルバリデーションの修正

## 動作確認

macOS / Chromeブラウザ / ruby -v3.2.2 / rails -v7.0.8 （ローカル開発環境）


## チェックリスト

- [x] Lintチェックをパスした