### PR TITLE
Monthly report #22

### DIFF
--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -4,7 +4,7 @@ class MonthlyReportsController < ApplicationController
     @monthly_reports = MonthlyReport.where(user_id:)
     render json: @monthly_reports.as_json(only: %i[content month])
   end
-    
+
   def create
     @monthly_report = MonthlyReport.new(report_params)
     if @monthly_report.save
@@ -13,9 +13,9 @@ class MonthlyReportsController < ApplicationController
       render json: @monthly_report.errors, status: :unprocessable_entity
     end
   end
-    
+
   private
-    
+
   def report_params
     params.require(:monthly_report).permit(:content, :month, :user_id)
   end

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -1,0 +1,22 @@
+class MonthlyReportsController < ApplicationController
+  def index
+    user_id = request.headers['user']
+    @monthly_reports = MonthlyReport.where(user_id:)
+    render json: @monthly_reports.as_json(only: %i[content month])
+  end
+    
+  def create
+    @monthly_report = MonthlyReport.new(report_params)
+    if @monthly_report.save
+      render json: { status: 'success' }
+    else
+      render json: @monthly_report.errors, status: :unprocessable_entity
+    end
+  end
+    
+  private
+    
+  def report_params
+    params.require(:monthly_report).permit(:content, :month, :user_id)
+  end
+end

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -1,0 +1,6 @@
+class MonthlyReport < ApplicationRecord
+  belongs_to :user
+
+  validates :content, presence: true
+  validates :month, presence: true, uniqueness: { scope: :user_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   belongs_to :group
   has_many :dairy_records, dependent: :destroy
   has_many :weekly_reports, dependent: :destroy
+  has_many :monthly_reports, dependent: :destroy
   has_many :weekly_targets, dependent: :destroy
   has_many :job_records, dependent: :destroy
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :customer_records, only: [:index]
   resources :customer_types, only: [:index]
   resources :weekly_reports, only: %i[index create]
+  resources :monthly_reports, only: %i[index create]
   resources :weekly_targets, only: %i[index create]
   resources :job_records, only: %i[index create]
 end

--- a/db/migrate/20240105062224_create_monthly_reports.rb
+++ b/db/migrate/20240105062224_create_monthly_reports.rb
@@ -1,0 +1,12 @@
+class CreateMonthlyReports < ActiveRecord::Migration[7.0]
+  def change
+    create_table :monthly_reports do |t|
+      t.text :content, null: false
+      t.string :month, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :monthly_reports, [:user_id, :month], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_25_031937) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_05_062224) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -68,6 +68,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_25_031937) do
     t.index ["name"], name: "index_jobs_on_name", unique: true
   end
 
+  create_table "monthly_reports", force: :cascade do |t|
+    t.text "content", null: false
+    t.string "month", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "month"], name: "index_monthly_reports_on_user_id_and_month", unique: true
+    t.index ["user_id"], name: "index_monthly_reports_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "line_id", null: false
     t.boolean "notifications", default: false
@@ -106,6 +116,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_25_031937) do
   add_foreign_key "dairy_records", "users"
   add_foreign_key "job_records", "jobs"
   add_foreign_key "job_records", "users"
+  add_foreign_key "monthly_reports", "users"
   add_foreign_key "users", "groups"
   add_foreign_key "weekly_reports", "users"
   add_foreign_key "weekly_targets", "users"


### PR DESCRIPTION
## 概要

MonthlyReport登録機能の作成

issue: #22 

## 変更点

- モデル, コントローラ, ルーティング作成
ユーザーは月に１件のみ月間レポートを作成できる

## 動作確認

macOS / Chromeブラウザ / ruby -v3.2.2 / rails -v7.0.8 （ローカル開発環境）
- フロントから送られた月間レポートデータを保存できることを確認


## チェックリスト

- [x] Lintチェックをパスした

## コメント
indexアクション仮