### PR TITLE
Token #95

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'dotenv-rails'
 
 gem 'line-bot-api'
 
+gem 'jwt'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
       rdoc
       reline (>= 0.3.8)
     json (2.7.1)
+    jwt (2.7.1)
     language_server-protocol (3.17.0.3)
     line-bot-api (1.28.0)
     loofah (2.22.0)
@@ -208,6 +209,7 @@ DEPENDENCIES
   bootsnap
   debug
   dotenv-rails
+  jwt
   line-bot-api
   pg (~> 1.1)
   puma (~> 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+  include Authenticable
 end

--- a/app/controllers/concerns/authenticable.rb
+++ b/app/controllers/concerns/authenticable.rb
@@ -1,33 +1,32 @@
 module Authenticable
   extend ActiveSupport::Concern
-  
+
   included do
     before_action :authenticate_user
   end
 
   private
-  
+
   def authenticate_user
     # ヘッダーからトークンを取得
     token = request.headers['Authorization'].to_s.split(' ').last
-  
+
     begin
-    # トークンをデコードしてユーザーを検証
+      # トークンをデコードしてユーザーを検証
       payload = decode_token(token)
       @current_user = User.find_by(id: payload['user_id'])
-      rescue JWT::DecodeError => e
-        # 認証エラーの場合
-        render json: { errors: 'Unauthorized' }, status: :unauthorized and return
-      end
-  
-      # ユーザーが存在しない場合の処理
-      render json: { errors: 'User not found' }, status: :not_found if @current_user.nil?
-    end
-  
-    def decode_token(token)
-      JWT.decode(token, Rails.application.secrets.secret_key_base).first
     rescue JWT::DecodeError => e
-      raise
+      # 認証エラーの場合
+      render json: { errors: 'Unauthorized' }, status: :unauthorized and return
     end
+
+    # ユーザーが存在しない場合の処理
+    render json: { errors: 'User not found' }, status: :not_found if @current_user.nil?
   end
-  
+
+  def decode_token(token)
+    JWT.decode(token, Rails.application.secrets.secret_key_base).first
+  rescue JWT::DecodeError => e
+    raise
+  end
+end

--- a/app/controllers/concerns/authenticable.rb
+++ b/app/controllers/concerns/authenticable.rb
@@ -9,24 +9,17 @@ module Authenticable
 
   def authenticate_user
     # ヘッダーからトークンを取得
-    token = request.headers['Authorization'].to_s.split(' ').last
+    token = request.headers['Authorization'].to_s.split.last
 
     begin
       # トークンをデコードしてユーザーを検証
-      payload = decode_token(token)
+      payload = JWT.decode(token, Rails.application.secrets.secret_key_base).first
       @current_user = User.find_by(id: payload['user_id'])
-    rescue JWT::DecodeError => e
+    rescue JWT::DecodeError
       # 認証エラーの場合
       render json: { errors: 'Unauthorized' }, status: :unauthorized and return
     end
-
     # ユーザーが存在しない場合の処理
     render json: { errors: 'User not found' }, status: :not_found if @current_user.nil?
-  end
-
-  def decode_token(token)
-    JWT.decode(token, Rails.application.secrets.secret_key_base).first
-  rescue JWT::DecodeError => e
-    raise
   end
 end

--- a/app/controllers/concerns/authenticable.rb
+++ b/app/controllers/concerns/authenticable.rb
@@ -1,0 +1,33 @@
+module Authenticable
+  extend ActiveSupport::Concern
+  
+  included do
+    before_action :authenticate_user
+  end
+
+  private
+  
+  def authenticate_user
+    # ヘッダーからトークンを取得
+    token = request.headers['Authorization'].to_s.split(' ').last
+  
+    begin
+    # トークンをデコードしてユーザーを検証
+      payload = decode_token(token)
+      @current_user = User.find_by(id: payload['user_id'])
+      rescue JWT::DecodeError => e
+        # 認証エラーの場合
+        render json: { errors: 'Unauthorized' }, status: :unauthorized and return
+      end
+  
+      # ユーザーが存在しない場合の処理
+      render json: { errors: 'User not found' }, status: :not_found if @current_user.nil?
+    end
+  
+    def decode_token(token)
+      JWT.decode(token, Rails.application.secrets.secret_key_base).first
+    rescue JWT::DecodeError => e
+      raise
+    end
+  end
+  

--- a/app/controllers/customer_records_controller.rb
+++ b/app/controllers/customer_records_controller.rb
@@ -1,6 +1,6 @@
 class CustomerRecordsController < ApplicationController
   def index
-    user_id = request.headers['user']
+    user_id = @current_user.id
     render json: CustomerRecord.summary_by_user(user_id)
   end
 end

--- a/app/controllers/customer_types_controller.rb
+++ b/app/controllers/customer_types_controller.rb
@@ -1,6 +1,6 @@
 class CustomerTypesController < ApplicationController
   skip_before_action :authenticate_user
-  
+
   def index
     customer_types = CustomerType.order(:id)
     options = customer_types.map do |type|

--- a/app/controllers/customer_types_controller.rb
+++ b/app/controllers/customer_types_controller.rb
@@ -1,4 +1,6 @@
 class CustomerTypesController < ApplicationController
+  skip_before_action :authenticate_user
+  
   def index
     customer_types = CustomerType.order(:id)
     options = customer_types.map do |type|

--- a/app/controllers/dairy_records_controller.rb
+++ b/app/controllers/dairy_records_controller.rb
@@ -1,6 +1,6 @@
 class DairyRecordsController < ApplicationController
   def index
-    user_id = request.headers['user']
+    user_id = @current_user.id
     @dairy_records = DairyRecord.where(user_id:).order(:date)
     render json: @dairy_records.as_json(only: %i[average_spend count date set_rate total_amount total_number])
   end

--- a/app/controllers/job_records_controller.rb
+++ b/app/controllers/job_records_controller.rb
@@ -1,6 +1,6 @@
 class JobRecordsController < ApplicationController
   def index
-    user_id = request.headers['user']
+    user_id = @current_user.id
     @job_records = JobRecord.includes(:job).where(user_id:)
     render json: @job_records.map { |record|
       {

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -2,7 +2,7 @@ class MonthlyReportsController < ApplicationController
   before_action :set_monthly_report, only: [:update]
 
   def index
-    user_id = request.headers['user']
+    user_id = @current_user.id
     @monthly_reports = MonthlyReport.where(user_id:)
     render json: @monthly_reports.as_json(only: %i[id content month])
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  require 'jwt' 
+  require 'jwt'
 
   before_action :verify_api_token, only: [:authenticate]
   skip_before_action :authenticate_user, only: [:authenticate]
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
       # JWTトークンを生成
       token = encode_jwt(user.id)
       # トークンを返す
-      render json: { status: 'success', user: { token: token, user_id: user.id } }
+      render json: { status: 'success', user: { token:, user_id: user.id } }
     else
       Rails.logger.info "User validation failed: #{user.errors.full_messages}"
       render json: { status: 'error', errors: user.errors.full_messages }, status: :unprocessable_entity
@@ -52,7 +52,7 @@ class UsersController < ApplicationController
   end
 
   def encode_jwt(user_id)
-    payload = { user_id: user_id}
+    payload = { user_id: }
     JWT.encode(payload, Rails.application.secrets.secret_key_base)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
   skip_before_action :authenticate_user, only: [:authenticate]
 
   def authenticate
-    user = User.authenticate_with_line_id(user_params[:line_id], user_params[:name])
+    user = authenticate_user
     if user.save
       # JWTトークンを生成
       token = encode_jwt(user.id)
@@ -43,6 +43,10 @@ class UsersController < ApplicationController
 
   def user_notifications_params
     params.require(:user).permit(:notifications)
+  end
+
+  def authenticate_user
+    User.authenticate_with_line_id(user_params[:line_id], user_params[:name])
   end
 
   def verify_api_token

--- a/app/controllers/weekly_reports_controller.rb
+++ b/app/controllers/weekly_reports_controller.rb
@@ -1,6 +1,6 @@
 class WeeklyReportsController < ApplicationController
   def index
-    user_id = request.headers['user']
+    user_id = @current_user.id
     @weekly_reports = WeeklyReport.where(user_id:)
     render json: @weekly_reports.as_json(only: %i[content start_date end_date])
   end

--- a/app/controllers/weekly_targets_controller.rb
+++ b/app/controllers/weekly_targets_controller.rb
@@ -1,6 +1,6 @@
 class WeeklyTargetsController < ApplicationController
   def index
-    user_id = request.headers['user']
+    user_id = @current_user.id
     @weekly_targets = WeeklyTarget.where(user_id:)
     render json: @weekly_targets.as_json(only: %i[target start_date end_date])
   end


### PR DESCRIPTION
## 概要

フロントエンドとのデータとの受け渡しにトークンを追加

## 変更点

- フロントログイン時のcallbackでアクセスされる際にaccessTokenを生成して返す
- ユーザーに紐づくアクセスの際にaccessTokenを利用するよう変更

## 動作確認

macOS / Chromeブラウザ / ruby -v3.2.2 / rails -v7.0.8 （ローカル開発環境）
- フロントとのデータの受け渡しを確認

## チェックリスト

- [x] Lintチェックをパスした