### PR TITLE
🐛 : notification page #95

### DIFF
--- a/app/controllers/concerns/authenticable.rb
+++ b/app/controllers/concerns/authenticable.rb
@@ -13,7 +13,7 @@ module Authenticable
 
     begin
       # トークンをデコードしてユーザーを検証
-      payload = JWT.decode(token, ENV["SECRET_KEY_BASE"]).first
+      payload = JWT.decode(token, ENV.fetch('SECRET_KEY_BASE', nil)).first
       @current_user = User.find_by(id: payload['user_id'])
     rescue JWT::DecodeError
       # 認証エラーの場合

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
   skip_before_action :authenticate_user, only: [:authenticate]
 
   def authenticate
-    user = authenticate_user
+    user = authenticate_line_user
     if user.save
       # JWTトークンを生成
       token = encode_jwt(user.id)
@@ -45,7 +45,7 @@ class UsersController < ApplicationController
     params.require(:user).permit(:notifications)
   end
 
-  def authenticate_user
+  def authenticate_line_user
     User.authenticate_with_line_id(user_params[:line_id], user_params[:name])
   end
 
@@ -57,6 +57,6 @@ class UsersController < ApplicationController
 
   def encode_jwt(user_id)
     payload = { user_id: }
-    JWT.encode(payload, ENV["SECRET_KEY_BASE"])
+    JWT.encode(payload, ENV.fetch('SECRET_KEY_BASE', nil))
   end
 end


### PR DESCRIPTION
## 概要

通知設定ページが取得できないbug修正

## 変更点

- メソッド名の変更（名前の重複が問題だったため）

## 動作確認

macOS / Chromeブラウザ / ruby -v3.2.2 / rails -v7.0.8 （ローカル開発環境）
- 通知設定が取得できることを確認


## チェックリスト

- [x] Lintチェックをパスした
