### PR TITLE
Add customer types #70

### DIFF
--- a/app/controllers/admin/customer_types_controller.rb
+++ b/app/controllers/admin/customer_types_controller.rb
@@ -7,6 +7,15 @@ module Admin
       render json: { customer_types: transform_customer_types(customer_types) }
     end
 
+    def create
+      @customer_type = CustomerType.new(customer_type_params)
+      if @customer_type.save
+        render json: { status: 'success' }
+      else
+        render json: @customer_type.errors, status: :unprocessable_entity
+      end
+    end
+
     def update
       if @customer_type.update(customer_type_params)
         render json: @customer_type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :users, only: %i[index update destroy]
-    resources :customer_types, only: %i[index update destroy]
+    resources :customer_types, only: %i[index create update destroy]
     resources :dairy_records, only: %i[index destroy]
   end
 end

--- a/spec/requests/admin_customer_types_spec.rb
+++ b/spec/requests/admin_customer_types_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe 'AdminCustomerTypes', type: :request do
     context 'admin_userの場合' do
       valid_params = { customer_type: { name: 'new_customer' } }
       it '新しい客層タイプを作成する' do
-        expect { post '/admin/customer_types', headers: { 'Authorization' => "Bearer #{admin_token}" }, params: valid_params }
+        expect do
+          post '/admin/customer_types', headers: { 'Authorization' => "Bearer #{admin_token}" }, params: valid_params
+        end
           .to change(CustomerType, :count).by(+1)
         expect(response.status).to eq(200)
       end

--- a/spec/requests/admin_customer_types_spec.rb
+++ b/spec/requests/admin_customer_types_spec.rb
@@ -30,6 +30,26 @@ RSpec.describe 'AdminCustomerTypes', type: :request do
     end
   end
 
+  describe 'POST /admin/customer_types' do
+    context 'admin_userの場合' do
+      valid_params = { customer_type: { name: 'new_customer' } }
+      it '新しい客層タイプを作成する' do
+        expect { post '/admin/customer_types', headers: { 'Authorization' => "Bearer #{admin_token}" }, params: valid_params }
+          .to change(CustomerType, :count).by(+1)
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'general_userの場合' do
+      valid_params = { customer_type: { name: 'new_customer' } }
+      it '403エラーを返す' do
+        expect { post '/admin/customer_types', headers: { 'Authorization' => "Bearer #{token}" }, params: valid_params }
+          .not_to change(CustomerType, :count)
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+
   describe 'PATCH /admin/customer_types/:id' do
     context 'admin_userの場合' do
       valid_params = { customer_type: { name: 'update_name' } }


### PR DESCRIPTION
## 概要

管理画面から客層タイプの追加ができるよう機能追加
issue: #70 

## 変更点

- admin/customer_typesエンドポイントのアップデート
- 追加機能分のテスト追加

## 動作確認

macOS / Chromeブラウザ / ruby -v3.2.2 / rails -v7.0.8 （ローカル開発環境）
- フロントからデータを受け取り客層データの新規作成ができる

## チェックリスト

- [x] Lintチェックをパスした
- [x] RSpecをパスした
